### PR TITLE
Update redirect URLs

### DIFF
--- a/index.php
+++ b/index.php
@@ -902,23 +902,23 @@ function woo_custom_redirect_after_purchase()
                     if (empty($errorSlug)):
                         // If Error slug is left empty, redirect the customer his order checkout payment URL.
                         // This should be the default behaviour for better customer experience and better conversion. Noone wants to create his cart once again.
-                        $errorURL = $order->get_checkout_payment_url( $on_checkout = false );                
-                    endif;
-                    
-                    $order_status = "wc-cancelled";
-                    $order = new WC_Order($order_id);
-                    $items = $order->get_items();
-                    $order->update_status($order_status, __($invoiceData->error.'.', 'woocommerce'));
+                        $errorURL = $order->get_checkout_payment_url( $on_checkout = false );
+                    else :                    
+                        $order_status = "wc-cancelled";
+                        $order = new WC_Order($order_id);
+                        $items = $order->get_items();
+                        $order->update_status($order_status, __($invoiceData->error.'.', 'woocommerce'));
 
-                     //clear the cart first so things dont double up
-                    WC()->cart->empty_cart();
-                    foreach ($items as $item) {
-                        //now insert for each quantity
-                        $item_count = $item->get_quantity();
-                        for ($i = 0; $i < $item_count; $i++):
-                            WC()->cart->add_to_cart($item->get_product_id());
-                        endfor;
-                    }
+                        //clear the cart first so things dont double up
+                        WC()->cart->empty_cart();
+                        foreach ($items as $item) {
+                            //now insert for each quantity
+                            $item_count = $item->get_quantity();
+                            for ($i = 0; $i < $item_count; $i++):
+                                WC()->cart->add_to_cart($item->get_product_id());
+                            endfor;
+                        }
+                    endif;
                     wp_redirect($errorURL);
                     die();
                 endif;


### PR DESCRIPTION
[a089e06](https://github.com/bitpay/bitpay-checkout-for-woocommerce/pull/44/commits/a089e06939a8eaae5c92479dc949ee2d0d452f9b) : Update closeURL and errorURL fallbacks to Woocommerce `$order->get_checkout_payment_url()` page. This should be the default behaviour for a better customer experience and better conversion rate. No one wants extra useless steps to complete his order.

[c7eca52](https://github.com/bitpay/bitpay-checkout-for-woocommerce/pull/44/commits/c7eca52ba05a2e4c7550335e715b3c5769c9125d) : Because now by default we redirect errors to the `$order->get_checkout_payment_url()` page, we do not want to set the order as cancelled anymore. Only cancel it if the error slug isn't empty. Else, just redirect to let customer retry with Bitpay or another payment provider.