### PR TITLE
Fixes a bug when the IPN/webhook is received with "complete" status.

### DIFF
--- a/BitPayLib/class-bitpayipnprocess.php
+++ b/BitPayLib/class-bitpayipnprocess.php
@@ -173,14 +173,14 @@ class BitPayIpnProcess {
 	}
 
 	private function process_completed( Invoice $bitpay_invoice, WC_Order $order ): void {
-		$this->validate_bitpay_status_in_available_statuses( $bitpay_invoice, array( 'completed' ) );
+		$this->validate_bitpay_status_in_available_statuses( $bitpay_invoice, array( 'complete' ) );
 
 		$invoice_id             = $bitpay_invoice->getId();
 		$wordpress_order_status = $this->get_gateway_settings()['bitpay_checkout_order_process_complete_status'];
 		if ( WcGatewayBitpay::IGNORE_STATUS_VALUE === $wordpress_order_status ) {
 			$order->add_order_note(
 				$this->get_start_order_note( $invoice_id )
-				. 'has changed to Completed.  The order status has not been updated due to your settings.'
+				. 'has changed to Complete.  The order status has not been updated due to your settings.'
 			);
 			return;
 		}


### PR DESCRIPTION
When the "complete" IPN message was coming through this code would throw a RuntimeException with "Wrong BitPay status..." message, this is because this code was looking for a status "completed" instead of "complete".

Possibly the original developer might have gotten mixed up because Woocommerce order status is named "completed" but the BitPay invoice status is named "complete" which is very similar.