### PR TITLE
SP-940: Remove prefix from table check

### DIFF
--- a/BitPayLib/class-bitpaysupportpackage.php
+++ b/BitPayLib/class-bitpaysupportpackage.php
@@ -93,7 +93,7 @@ class BitPaySupportPackage {
 					'tables'       => array(
 						array(
 							'table'  => '_bitpay_checkout_transactions',
-							'exists' => $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}_bitpay_checkout_transactions'" ) ? 'yes' : 'no',
+							'exists' => $wpdb->get_var( "SHOW TABLES LIKE '_bitpay_checkout_transactions'" ) ? 'yes' : 'no',
 						),
 					),
 				),


### PR DESCRIPTION
This merge request removes a check for the WP DB prefix because it's not used on the bitpay_checkout_transactions table when the tables is created