### PR TITLE
SP-1128: Update supported versions in changelog/readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 # 6.0.0
 * Fixed a bug when the IPN/webhook is received with "complete" status
 * Add Unit & End2End tests
+* Updated SDK
+* Added Platform Info
+* Verifies Webhooks
 
 # 5.5.1
 * Fixed issue with payment logo url

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Visit the [Releases](https://github.com/bitpay/bitpay-checkout-for-woocommerce/r
 
 **BitPay Support:**
 
-* Last Cart Version Tested: Wordpress 6.5.2
+* Last Cart Version Tested: Wordpress 6.7.1
 * [GitHub Issues](https://github.com/bitpay/bitpay-checkout-for-woocommerce/issues)
 * [Support](https://support.bitpay.com/hc/en-us)
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: bitpay
 Tags: bitcoin, ether, ripple, bitcoin cash, ERC20, payments, bitpay, cryptocurrency, payment gateway
 Requires at least: 6.0
-Tested up to: 6.4.2
+Tested up to: 6.7.2
 WC requires at least: 8.0.0
-WC tested up to: 8.5.2
+WC tested up to: 9.5.2
 Requires PHP: 8.1
 Recommended PHP: 8.3
 Stable tag: 6.0.0
@@ -115,7 +115,10 @@ You can contact our support team via the following form https://bitpay.com/reque
 
 = 6.0.0 =
 * Fixed a bug when the IPN/webhook is received with "complete" status
-* * Add Unit & End2End tests
+* Add Unit & End2End tests
+* Updated SDK
+* Added Platform Info
+* Verifies Webhooks
 
 = 5.5.1 =
 * Fixed issue with payment logo url

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: bitpay
 Tags: bitcoin, ether, ripple, bitcoin cash, ERC20, payments, bitpay, cryptocurrency, payment gateway
 Requires at least: 6.0
-Tested up to: 6.7.2
+Tested up to: 6.7.1
 WC requires at least: 8.0.0
 WC tested up to: 9.5.2
 Requires PHP: 8.1
@@ -119,6 +119,7 @@ You can contact our support team via the following form https://bitpay.com/reque
 * Updated SDK
 * Added Platform Info
 * Verifies Webhooks
+* Tested compatibility with WordPress 6.7.1
 
 = 5.5.1 =
 * Fixed issue with payment logo url


### PR DESCRIPTION
This merge request updates the WP/Woo version supported by the BitPay plugin