### PR TITLE
[#105] Fix bug that causes register_activation_hook not to be called upon plugin activation

### DIFF
--- a/BitPayLib/class-bitpaypluginsetup.php
+++ b/BitPayLib/class-bitpaypluginsetup.php
@@ -55,8 +55,8 @@ class BitPayPluginSetup {
 	}
 
 	public function execute(): void {
-		register_activation_hook( __FILE__, array( $this, 'setup_plugin' ) );
-		register_activation_hook( __FILE__, array( $this, 'add_error_page' ) );
+		register_activation_hook( BITPAY_CHECKOUT_FOR_WC_PLUGIN_FILE, array( $this, 'setup_plugin' ) );
+		register_activation_hook( BITPAY_CHECKOUT_FOR_WC_PLUGIN_FILE, array( $this, 'add_error_page' ) );
 
 		add_action( 'plugins_loaded', array( $this, 'validate_wc_payment_gateway' ), 11 );
 		add_action( 'woocommerce_widget_shopping_cart_buttons', array( $this, 'bitpay_mini_checkout' ), 20 );

--- a/index.php
+++ b/index.php
@@ -17,5 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! defined( 'BITPAY_CHECKOUT_FOR_WC_PLUGIN_FILE' ) ) {
+	define( 'BITPAY_CHECKOUT_FOR_WC_PLUGIN_FILE', __FILE__ );
+}
+
 $bitpay_plugin_setup = new BitPayPluginSetup();
 $bitpay_plugin_setup->execute();

--- a/tests/Unit/index.tests.php
+++ b/tests/Unit/index.tests.php
@@ -17,5 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! defined( 'BITPAY_CHECKOUT_FOR_WC_PLUGIN_FILE' ) ) {
+	define( 'BITPAY_CHECKOUT_FOR_WC_PLUGIN_FILE', __FILE__ );
+}
+
 $bitpay_plugin_setup = new BitPayPluginSetup();
 $bitpay_plugin_setup->execute();


### PR DESCRIPTION
**IMPORTANT** Once a new version of the plugin has been uploaded, you must deactivate it and activate it again.
