### PR TITLE
Security: Fix untrusted input vulnerability in release workflow - 7.1.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} /home/runner/work/release/*
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" /home/runner/work/release/*
 
       - name: Remove .git directory
         run: rm -rf .git/ -R


### PR DESCRIPTION
## Security Fix: Prevent Command Injection in Release Workflow

### Summary
This PR fixes a command injection vulnerability in the GitHub Actions release workflow by moving all untrusted inputs and GitHub context variables to environment variables.

### Problem
The workflow was directly interpolating user inputs and GitHub context variables into shell commands, which could allow command injection attacks. Specifically:

- `${{ github.event.release.tag_name }}` - GitHub context variable

### Solution
All potentially untrusted values are now passed through environment variables before being used in shell commands. This ensures they are treated as literal strings rather than being evaluated as code.

**Changes made:**
1. Added `RELEASE_TAG` environment variable to capture the release tag name
2. Updated the `gh release upload` command to use `"$RELEASE_TAG"` instead of direct interpolation

### Security Impact
This follows the security best practices outlined in the [GitHub Security Lab advisory](https://securitylab.github.com/resources/github-actions-untrusted-input/) and prevents potential command injection through GitHub Actions expressions.

### Testing
- [ ] Workflow syntax is valid
- [ ] No functional changes to workflow behavior
- [ ] All steps continue to work as expected