### PR TITLE
Implement Permission Check for Cancel Order Endpoint

### DIFF
--- a/BitPayLib/class-bitpaycancelorder.php
+++ b/BitPayLib/class-bitpaycancelorder.php
@@ -55,6 +55,26 @@ class BitPayCancelOrder {
 		$this->clear_cookie_for_invoice_id();
 	}
 
+	public function can_execute( ?string $invoice_id ): bool {
+		if ( ! isset( $_COOKIE[ BitPayPluginSetup::COOKIE_INVOICE_ID_NAME ] ) ) {
+			return false;
+		}
+
+		$cookie_value = sanitize_text_field( wp_unslash( $_COOKIE[ BitPayPluginSetup::COOKIE_INVOICE_ID_NAME ] ) );
+		if ( ! $invoice_id ) {
+			return false;
+		}
+
+		$order_id = $this->transactions->get_order_id_by_invoice_id( $invoice_id );
+		if ( ! $order_id ) {
+			return false;
+		}
+
+		$order = new \WC_Order( $order_id );
+
+		return sha1( $invoice_id . ':' . $order->get_id() . ':' . $order->get_billing_email() ) === $cookie_value;
+	}
+
 	private function clear_cookie_for_invoice_id(): void {
 		setcookie( BitPayPluginSetup::COOKIE_INVOICE_ID_NAME, '', time() - 3600 );
 	}

--- a/BitPayLib/class-bitpayinvoicecreate.php
+++ b/BitPayLib/class-bitpayinvoicecreate.php
@@ -68,7 +68,7 @@ class BitPayInvoiceCreate {
 			$this->bitpay_logger->execute( $bitpay_invoice->toArray(), 'NEW BITPAY INVOICE', true );
 
 			$invoice_id = $bitpay_invoice->getId();
-			$this->set_cookie_for_redirects_and_updating_order_status( $invoice_id );
+			$this->set_cookie_for_redirects_and_updating_order_status( $invoice_id, $order->get_id(), $order->get_billing_email() );
 
 			$this->bitpay_checkout_insert_order_note( $order_id, $invoice_id );
 
@@ -123,9 +123,9 @@ class BitPayInvoiceCreate {
 		setcookie( BitPayPluginSetup::COOKIE_INVOICE_ID_NAME, '', time() - 3600 );
 	}
 
-	private function set_cookie_for_redirects_and_updating_order_status( ?string $invoice_id ): void {
+	private function set_cookie_for_redirects_and_updating_order_status( ?string $invoice_id, ?int $order_id = null, ?string $billing_email = null ): void {
 		$cookie_name  = BitPayPluginSetup::COOKIE_INVOICE_ID_NAME;
-		$cookie_value = $invoice_id;
+		$cookie_value = sha1( $invoice_id . ':' . $order_id . ':' . $billing_email );
 		setcookie( $cookie_name, $cookie_value, time() + ( 86400 * 30 ), '/' );
 	}
 }

--- a/BitPayLib/class-bitpaypluginsetup.php
+++ b/BitPayLib/class-bitpaypluginsetup.php
@@ -90,7 +90,7 @@ class BitPayPluginSetup {
 					array(
 						'methods'             => 'POST,GET',
 						'callback'            => array( $this, 'cancel_order' ),
-						'permission_callback' => '__return_true',
+						'permission_callback' => array( $this, 'check_cancel_order_permissions' ),
 					)
 				);
 				register_rest_route(
@@ -186,6 +186,10 @@ class BitPayPluginSetup {
 
 	public function cancel_order( WP_REST_Request $request ): void {
 		$this->bitpay_cancel_order->execute( $request );
+	}
+
+	public function check_cancel_order_permissions( WP_REST_Request $request ): bool {
+		return $this->bitpay_cancel_order->can_execute( $request->get_param( 'invoiceid' ) );
 	}
 
 	public function bitpay_checkout_custom_message( $order_id ): void {


### PR DESCRIPTION
### Summary
This PR addresses a security vulnerability by adding proper permission checks to the cancel order REST API endpoint, preventing unauthorized order cancellations.

### Problem
The /bitpay/cartfix/restore REST endpoint previously used __return_true as its permission callback, allowing anyone to cancel any order without authentication or authorization.

### Solution
Implemented a cookie-based authentication mechanism to verify that only the legitimate user who initiated the order can cancel it.
