### PR TITLE
Do not create or cancel invoices for orders that are already paid

### DIFF
--- a/BitPayLib/class-bitpayinvoicecreate.php
+++ b/BitPayLib/class-bitpayinvoicecreate.php
@@ -60,6 +60,17 @@ class BitPayInvoiceCreate {
 			if ( $order->get_payment_method() !== 'bitpay_checkout_gateway' ) {
 				return;
 			}
+
+			if ( ! $order->needs_payment() ) {
+				$this->bitpay_logger->execute(
+					'Order ' . $order->get_id() . ' does not need payment (status: '
+						. $order->get_status() . '). Skipping invoice creation.',
+					'NEW BITPAY INVOICE',
+					true
+				);
+				return;
+			}
+
 			$bitpay_invoice = $this->bitpay_invoice_factory->create_by_wc_order( $order );
 			$bitpay_invoice = $this->client_factory->create()->createInvoice( $bitpay_invoice, Facade::POS, false );
 
@@ -84,7 +95,10 @@ class BitPayInvoiceCreate {
 			$error_url = get_home_url() . '/' . $bitpay_checkout_options['bitpay_checkout_error'];
 			$order     = $this->wordpress_helper->get_order( $order_id );
 			$items     = $order->get_items();
-			$order->update_status( 'wc-cancelled', __( $e->getMessage() . '.', 'woocommerce' ) ); // phpcs:ignore
+
+			if ( ! $order->is_paid() ) {
+				$order->update_status( 'wc-cancelled', __( $e->getMessage() . '.', 'woocommerce' ) ); // phpcs:ignore
+			}
 
 			// clear the cart first so things dont double up.
 			WC()->cart->empty_cart();

--- a/BitPayLib/class-bitpayipnprocess.php
+++ b/BitPayLib/class-bitpayipnprocess.php
@@ -288,6 +288,15 @@ class BitPayIpnProcess {
 
 	private function process_abandoned( Invoice $bitpay_invoice, WC_Order $order ): void {
 		$this->validate_bitpay_status_in_available_statuses( $bitpay_invoice, array( 'expired' ) );
+
+		if ( ! $this->should_downgrade_order( $order ) ) {
+			$order->add_order_note(
+				$this->get_start_order_note( $bitpay_invoice->getId() )
+				. 'has expired. The order status has not been updated because the order is already paid.'
+			);
+			return;
+		}
+
 		$underpaid_amount       = $bitpay_invoice->getUnderpaidAmount();
 		$wordpress_order_status = $this->bitpay_wordpress_helper
 			->get_bitpay_gateway_option( 'bitpay_checkout_order_expired_status' );
@@ -355,6 +364,20 @@ class BitPayIpnProcess {
 		}
 
 		return true;
+	}
+
+	/**
+	 * We don't want to downgrade an order that has already been paid.
+	 *
+	 * A spurious or late invoice event must never move a paid order back to a
+	 * non-paid status. Same intent as should_process_completed_action(), applied
+	 * to the handlers that lower the order status.
+	 *
+	 * @param WC_Order $order WC order.
+	 * @return bool
+	 */
+	private function should_downgrade_order( WC_Order $order ): bool {
+		return ! $order->is_paid();
 	}
 
 	private function should_process_refund(): bool {

--- a/tests/Unit/BitPayLib/test-bitpayipnprocess.php
+++ b/tests/Unit/BitPayLib/test-bitpayipnprocess.php
@@ -569,6 +569,74 @@ class BitPayIpnProcessTest extends TestCase {
 	}
 
 	/**
+	 * A spurious invoice generated for an order that was already paid must not
+	 * cancel that order when it expires. See issue #153.
+	 *
+	 * @test
+	 */
+	public function it_should_not_cancel_an_already_paid_order_when_an_invoice_expires(): void {
+		// given
+		$wordpress_helper      = $this->get_wordpress_helper();
+		$request               = $this->getMockBuilder( \WP_REST_Request::class )->getMock();
+		$transactions          = $this->get_checkout_transactions();
+		$bitpay_invoice        = $this->getMockBuilder( \BitPaySDK\Model\Invoice\Invoice::class )->getMock();
+		$bitpay_client         = $this->getMockBuilder( \BitPaySDK\Client::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$logger                = $this->get_bitpay_logger();
+		$bitpay_client_factory = $this->getMockBuilder( BitPayClientFactory::class )
+			->disableOriginalConstructor()->getMock();
+		$wc_order              = $this->get_wc_order();
+
+		// the order has already been paid.
+		$wc_order->method( 'is_paid' )->willReturn( true );
+
+		$transactions->method( 'count_transaction_id' )->willReturn( 1 );
+		$bitpay_invoice->method( 'getStatus' )->willReturn( 'expired' );
+		$bitpay_invoice->method( 'getId' )->willReturn( self::BITPAY_INVOICE_ID );
+		$bitpay_invoice->method( 'getPrice' )->willReturn( 100.00 );
+		$bitpay_invoice->method( 'getCurrency' )->willReturn( 'USD' );
+		$bitpay_invoice->method( 'getOrderId' )->willReturn( self::BITPAY_INVOICE_ID );
+		$request->method( 'get_body' )
+			->willReturn(
+				file_get_contents( __DIR__ . '/json/bitpay_expired_ipn_webhook.json' )
+			);
+		$request->expects( self::once() )->method( 'get_header' )->with( 'x-signature' )
+			->willReturn( 'x-signature-header-value' );
+		$bitpay_client_factory->method( 'create' )->willReturn( $bitpay_client );
+		$bitpay_client->method( 'getInvoice' )->with( self::BITPAY_INVOICE_ID, \BitPaySDK\Model\Facade::POS, false )
+			->willReturn( $bitpay_invoice );
+		$wordpress_helper->expects( self::once() )->method( 'get_order' )
+			->with( self::WC_ORDER_ID )
+			->willReturn( $wc_order );
+
+		$webhook_verifier = $this->get_bitpay_webhook_verifier();
+		$webhook_verifier->method( 'verify' )->willReturn( true );
+
+		$testedClass = $this->getTestedClass(
+			$wordpress_helper,
+			$bitpay_client_factory,
+			$transactions,
+			$logger,
+			$webhook_verifier,
+			$this->get_bitpay_payment_settings()
+		);
+
+		// then
+		$wc_order->expects( self::never() )->method( 'update_status' );
+		$wc_order
+			->expects( self::once() )
+			->method( 'add_order_note' )
+			->with(
+				'BitPay Invoice ID: <a target = "_blank" href = "//test.bitpay.com/dashboard/payments/someId">someId</a>'
+				. ' has expired. The order status has not been updated because the order is already paid.'
+			);
+
+		// when
+		$testedClass->execute( $request );
+	}
+
+	/**
 	 * @test
 	 */
 	public function it_should_refund_order(): void {


### PR DESCRIPTION
## Problem

Reported in #153: orders that were already paid and shipped receive new
BitPay invoices days or months later, and when those invoices expire the
order flips from Completed to Cancelled — reversing stock and desyncing
downstream accounting. The reporting merchant found 52 orders with more than
one invoice, one with 27.

## Root cause

Three separate paths, all the same family: acting on a secondary or late
event instead of the order's authoritative paid state.

1. `BitPayInvoiceCreate::execute()` runs on `template_redirect` over the
   `order-received` page and calls `createInvoice()` without checking whether
   the order still needs payment. Any GET to that URL — a link scanner, a
   crawler, a customer reopening an old confirmation email — mints a new
   invoice.
2. `BitPayIpnProcess::process_abandoned()` (the `invoice_expired` handler)
   cancels the order without looking at its current status.
3. The `BitPayException` handler in `execute()` cancels the order on invoice
   creation failure, again without checking whether it is paid.

## Fix

Three guards, defence in depth. Path 1 stops spurious invoices at the source;
paths 2 and 3 make sure a paid order is never downgraded even if one slips
through.

This is not a new concept for this codebase: `should_process_completed_action()`
already exists to keep a completed order from being moved back ("We don't want
to change complete order to process"), but it is applied only in
`process_completed()`. The new `should_downgrade_order()` helper extends that
same intent to the handlers that lower the order status.

## Verification

Verified on WordPress 6.9.4 + WooCommerce 10.6.1, two orders in the same run:

| Order | Status | needs_payment | Requests | Result |
|---|---|---|---|---|
| #15 | completed | no | 3 × GET order-received | `200`, no redirect, **no new invoice** |
| #16 | pending | yes | 1 × GET order-received | `302` to the BitPay invoice, **invoice created** |

Before the fix, #15 produced a new invoice on every single reload — five in
51 seconds. The invoice id in #16's redirect matches the row written to the
transactions table, confirming legitimate checkout is untouched.

Path 2 is covered by a new unit test in `test-bitpayipnprocess.php`: an
`invoice_expired` IPN against a paid order must not call `update_status()`.
Path 3 is guarded but not yet covered by an automated test.

## Not included

`process_failed()`, `process_declined()` and `process_refunded()` lower the
order status through the same unguarded path. They are not part of the
reported issue and changing them affects scenarios nobody has reported, so
they are left out here — happy to open a follow-up issue.

Refs #153